### PR TITLE
fix: set default token decimals if token is undefined when creating pool

### DIFF
--- a/src/pages/DexV2/Pool/components/CreateActions.tsx
+++ b/src/pages/DexV2/Pool/components/CreateActions.tsx
@@ -11,6 +11,7 @@ import { ApprovalAction } from 'hooks/dex-v2/approvals/types'
 import { useTokens } from 'state/dexV2/tokens/hooks/useTokens'
 import { scale } from 'lib/utils'
 import { BigNumber } from 'ethers'
+import { DEFAULT_TOKEN_DECIMALS } from 'constants/dexV2/tokens'
 
 interface Props {
   tokenAddresses: string[]
@@ -53,7 +54,7 @@ const CreateActions: React.FC<Props> = ({ amounts, tokenAddresses, goBack }) => 
   const amountsToApprove = amounts.map((amount, index) => {
     const tokenAddress = tokenAddresses[index]
     const _amount = new BigNumberJs(amount)
-    const scaledAmount = scale(_amount, tokens[tokenAddress].decimals)
+    const scaledAmount = scale(_amount, tokens[tokenAddress]?.decimals || DEFAULT_TOKEN_DECIMALS)
     return {
       address: tokenAddress,
       amount: BigNumber.from(scaledAmount.toFixed(0, BigNumberJs.ROUND_FLOOR)),
@@ -74,7 +75,7 @@ const CreateActions: React.FC<Props> = ({ amounts, tokenAddresses, goBack }) => 
       amountsToApprove,
       spender: networkConfig.addresses.vault,
       actionType: ApprovalAction.AddLiquidity,
-      // forceMax: false,
+      forceMax: false,
     })
     setLoading(false)
     setActions([...approvalActions, ...initActions])


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- set default token decimals if token is undefined when creating pool
-

## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
