### PR TITLE
fix: [IXSPD1-2705] Invalid Files when update info of old issuances

### DIFF
--- a/src/state/launchpad/hooks.ts
+++ b/src/state/launchpad/hooks.ts
@@ -1096,15 +1096,15 @@ export const useOfferFormInitialValues = (
         faq: payload.faq?.length ? payload.faq : initialValues.faq,
         members: payload.members?.length
           ? payload.members.map(
-            (member) =>
-            ({
-              id: member.id,
-              name: member.name,
-              role: member.title,
-              about: member.description,
-              photo: files.find((x) => x.id === member.avatar?.id),
-            } as TeamMember)
-          )
+              (member) =>
+                ({
+                  id: member.id,
+                  name: member.name,
+                  role: member.title,
+                  about: member.description,
+                  photo: files.find((x) => x.id === member.avatar?.id),
+                } as TeamMember)
+            )
           : initialValues.members,
 
         social: Object.entries(payload.socialMedia || {}).map(([name, link]) => ({
@@ -1120,20 +1120,20 @@ export const useOfferFormInitialValues = (
 
         additionalDocuments: documents.length
           ? documents.map((document: any) => {
-            const file = files.find((x) => x.id === document.file?.id)
+              const file = files.find((x) => x.id === document.file?.id)
 
-            return { file: file, asset: document?.file } as AdditionalDocument
-          })
+              return { file: file, asset: document?.file } as AdditionalDocument
+            })
           : initialValues.additionalDocuments,
 
         purchaseAgreement: { file: purchaseAgreement },
         investmentMemorandum: { file: investmentMemorandum },
         otherExecutionDocuments: otherExecutionDocuments.length
           ? otherExecutionDocuments.map((document: any) => {
-            const file = files.find((x) => x.id === document.file?.id)
+              const file = files.find((x) => x.id === document.file?.id)
 
-            return { file: file, asset: document?.file } as AdditionalDocument
-          })
+              return { file: file, asset: document?.file } as AdditionalDocument
+            })
           : initialValues.otherExecutionDocuments,
 
         hasPresale: payload.hasPresale,
@@ -1214,7 +1214,10 @@ export const useSubmitOffer = () => {
       const findDoc = (prefix: 'member.photo' | 'document' | 'image' | 'otherExecutionDocument', idx: number) =>
         uploadedFiles.find((x) => x.name === `${prefix}.${idx}`)?.id
       const purchaseAgreementId =
-        uploadedFiles.find((x) => x.name === 'purchaseAgreement')?.id || payload.purchaseAgreement?.file?.file?.id || null
+        uploadedFiles.find((x) => x.name === 'purchaseAgreement')?.id ||
+        payload.purchaseAgreement?.file?.file?.id ||
+        null
+
       const investmentMemorandumId =
         uploadedFiles.find((x) => x.name === 'investmentMemorandum')?.id ||
         payload.investmentMemorandum?.file?.file?.id ||
@@ -1405,9 +1408,13 @@ export const useMinimalOfferEdit = () => {
       files.find((x) => x.name === `${prefix}.${idx}`)?.id
 
     const purchaseAgreementId =
-      files.find((x) => x.name === 'purchaseAgreement')?.id || payload.purchaseAgreement?.file?.id || null
+      files.find((x) => x.name === 'purchaseAgreement')?.id || // file id is from uploaded files
+      payload.purchaseAgreement?.file?.file.id || // if we keep the file in the state
+      null
     const investmentMemorandumId =
-      files.find((x) => x.name === 'investmentMemorandum')?.id || payload.investmentMemorandum?.file?.id || null
+      files.find((x) => x.name === 'investmentMemorandum')?.id || // file id is from uploaded files
+      payload.investmentMemorandum?.file?.file.id || // if we keep the file in the state
+      null
 
     const executionDocuments = []
     if (purchaseAgreementId)


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- Invalid Files when update info of old issuances
- covers 3 cases: creating offer, updating offer without file changing, updating offer with file changes

## Attached Links

1. Jira ticket: [IXSPD1-2705]
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments


[IXSPD1-2705]: https://investax.atlassian.net/browse/IXSPD1-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ