### PR TITLE
fix: [IXSPD1-2711] avoid dropping the search query when clicking on Dex v2

### DIFF
--- a/src/components/Header/HeaderLinks.tsx
+++ b/src/components/Header/HeaderLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { Trans } from '@lingui/macro'
 import { darken } from 'polished'
 import { NavLink } from 'react-router-dom'
@@ -53,7 +53,6 @@ export const HeaderLinks = () => {
       [config]
     )
 
-    //
     return (
       <PopOverContent
         onClick={(e: any) => (e ? e.stopPropagation() : null)}
@@ -234,6 +233,7 @@ export const HeaderLinks = () => {
           ref={v2Node as any}
           id="dexV2-nav-link"
           to="#"
+          onClick={(e) => e.preventDefault()}
           isActive={(match, { pathname }) => pathname.startsWith('/v2')}
         >
           <Popover hideArrow show={openV2} content={<DexV2Popover />} placement="bottom-start">


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- avoid dropping the search query when clicking on Dex v2
-
-

## Attached Links

1. Jira ticket: [IXSPD1-2711]
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments


[IXSPD1-2711]: https://investax.atlassian.net/browse/IXSPD1-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ