### PR TITLE
fix: inject token list instead of replacing

### DIFF
--- a/src/state/dexV2/tokens/hooks/useTokens.ts
+++ b/src/state/dexV2/tokens/hooks/useTokens.ts
@@ -214,7 +214,14 @@ export const useTokens = () => {
       omit(allTokens, tokenListUris.Balancer.Allowlisted)
     )
 
-    dispatch(setTokensState({ injectedTokens: newTokens }))
+    dispatch(
+      setTokensState({
+        injectedTokens: {
+          ...state.injectedTokens,
+          ...newTokens,
+        },
+      })
+    )
     // await forChange(onchainDataLoading, false);
   }
 


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- inject token list instead of replacing
- When that code injects the tokens, actually it replaces the list of token, from list A to B. So the get token balance function will be triggered and replace the balances. That why we encounter the UI re-render when the balance change, in the list A include the balance of pool but in the list B doesn’t.

## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
