### PR TITLE
fix: [IXSPD1-2749] optimize subgraph request

### DIFF
--- a/src/hooks/dex-v2/pools/usePoolDayDatas.ts
+++ b/src/hooks/dex-v2/pools/usePoolDayDatas.ts
@@ -1,9 +1,18 @@
 import { useMemo } from 'react'
 import usePoolDayDatasQuery from '../queries/usePoolDayDatasQuery'
 import { SubgraphPoolDayData } from 'services/balancer/poolDayDatas/types'
+import usePools from './usePools'
 
-export default function usePoolDayDatas(poolAddresses: string[]) {
-  const { data, isLoading } = usePoolDayDatasQuery({}, { poolAddresses })
+export default function usePoolDayDatas() {
+  const { pools } = usePools()
+  const poolAddresses = pools.map((pool) => pool.address)
+
+  const { data, isLoading } = usePoolDayDatasQuery(
+    {
+      enabled: poolAddresses.length > 0,
+    },
+    { poolAddresses }
+  )
 
   const poolDayDatas = useMemo(() => {
     return data?.reduce((acc: any, poolDayData: SubgraphPoolDayData) => {

--- a/src/hooks/dex-v2/pools/usePools.ts
+++ b/src/hooks/dex-v2/pools/usePools.ts
@@ -15,6 +15,7 @@ export type UsePoolsProps = {
   poolIds?: string[]
   poolTypes?: PoolType[]
   poolAttributes?: PoolAttributeFilter[]
+  enabled?: boolean
 }
 
 export default function usePools({
@@ -23,6 +24,7 @@ export default function usePools({
   poolIds = [],
   poolTypes = [],
   poolAttributes = [],
+  enabled = true,
 }: UsePoolsProps = {}) {
   // Create filter options object – similar to Vue's computed property.
   // @ts-ignore
@@ -41,7 +43,7 @@ export default function usePools({
   const poolsQuery = usePoolsQuery(
     filterOptions,
     // @ts-ignore
-    { enabled: true, refetchOnWindowFocus: false, placeholderData: true },
+    { enabled, refetchOnWindowFocus: false, placeholderData: true },
     false
   )
 

--- a/src/hooks/dex-v2/queries/useGaugesQuery.ts
+++ b/src/hooks/dex-v2/queries/useGaugesQuery.ts
@@ -34,9 +34,9 @@ export default function useGaugesQuery(options: QueryOptions = {}) {
    * QUERY OPTIONS
    */
   const queryOptions = {
-    enabled: true,
     ...options,
     queryKey,
+    staleTime: 60 * 1000, // 1 minute
   }
 
   return useQuery<QueryResponse>({ queryFn, ...queryOptions })

--- a/src/hooks/dex-v2/useTradingFeeApr.ts
+++ b/src/hooks/dex-v2/useTradingFeeApr.ts
@@ -8,13 +8,14 @@ import { configService } from 'services/config/config.service'
 import { bptPriceFor } from './usePoolHelpers'
 import { bnum, scale } from 'lib/utils'
 import useGauges from './pools/useGauges'
-import usePoolDayDatasQuery from './queries/usePoolDayDatasQuery'
 import { useMemo } from 'react'
 import { LP_DECIMALS } from 'pages/DexV2/Pool/Staking/constants'
+import usePoolDayDatas from './pools/usePoolDayDatas'
 
 export default function useTradingFeeApr(pool: Pool): string {
   const { gaugeFor } = useGauges()
-  const { data: dailySwaps } = usePoolDayDatasQuery({}, { poolAddresses: [pool.address] })
+  const { poolDayDatasFor } = usePoolDayDatas()
+  const dailySwaps = poolDayDatasFor(pool.address)
 
   const gaugeAddress = gaugeFor(pool.address)?.address
   const bptTokenPrice = bptPriceFor(pool)

--- a/src/pages/DexV2/Dashboard/hooks/useLiquidityPool.ts
+++ b/src/pages/DexV2/Dashboard/hooks/useLiquidityPool.ts
@@ -31,6 +31,7 @@ const useLiquidityPool = () => {
 
   const { pools, isLoading: isPoolsLoading } = usePools({
     poolIds: joinedPoolIds,
+    enabled: joinedPoolIds?.length > 0,
   })
 
   const poolContracts = pools?.flatMap((pool) => [
@@ -126,7 +127,7 @@ const useLiquidityPool = () => {
 
   return {
     pools,
-    isPoolsLoading,
+    isPoolsLoading: isPoolsLoading || joinExits.isLoading,
     lpSupplyByPool,
     userLpBalanceByPool,
     userGaugeBalanceByGauge,

--- a/src/pages/DexV2/Pool/Detail/components/PoolStatCards.tsx
+++ b/src/pages/DexV2/Pool/Detail/components/PoolStatCards.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const PoolAprCard = ({ pool }: { pool: Pool }) => {
-  const { poolDayDatasFor } = usePoolDayDatas([pool.address])
+  const { poolDayDatasFor } = usePoolDayDatas()
   const poolApr = getPoolAprValue(pool, poolDayDatasFor(pool.address))
 
   return <>{numF('apr', poolApr)}</>

--- a/src/pages/DexV2/Pool/List/PoolList.tsx
+++ b/src/pages/DexV2/Pool/List/PoolList.tsx
@@ -18,7 +18,6 @@ import Asset from 'pages/DexV2/common/Asset'
 import usePools from 'hooks/dex-v2/pools/usePools'
 import LoadingBlock from 'pages/DexV2/common/LoadingBlock'
 import { PinnedContentButton } from 'components/Button'
-import { bnum } from 'lib/utils'
 import usePoolDayDatas from 'hooks/dex-v2/pools/usePoolDayDatas'
 import { SubgraphPoolDayData } from 'services/balancer/poolDayDatas/types'
 import { useTokens } from 'state/dexV2/tokens/hooks/useTokens'
@@ -53,7 +52,7 @@ interface IBody {
   items: any[]
 }
 const Body = ({ items }: IBody) => {
-  const { poolDayDatasFor } = usePoolDayDatas(items.map((pool) => pool.address))
+  const { poolDayDatasFor } = usePoolDayDatas()
 
   return (
     <BodyContainer>

--- a/src/pages/DexV2/Pool/Staking/StakingCard.tsx
+++ b/src/pages/DexV2/Pool/Staking/StakingCard.tsx
@@ -27,7 +27,7 @@ type Props = {
 }
 
 const StakingCard: React.FC<Props> = ({ pool }) => {
-  const { poolDayDatasFor } = usePoolDayDatas([pool.address])
+  const { poolDayDatasFor } = usePoolDayDatas()
   const [isStakePreviewVisible, setIsStakePreviewVisible] = useState(false)
   const [stakeAction, setStakeAction] = useState<StakeAction>('stake')
 


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- The request to retrieve poolDayDatas should be enable when the token addresses is not empty.
- In the Dashboard, the component triggers usePools function to retrieve the pool list but we only need the pools that user involve (added liquidity or staked). So, we will avoid calling usePools when joinedPoolIds is empty by conditionally invoking the hook only if there are pool IDs.
- I use the query key in useGaugesQuery is static and should not cause re-fetches by itself. However, the reason my request is being re-executed multiple times is because you are calling useGauges() in multiple places. So, I add the staleTime to ensure the cached data will be used at least 1 minute.
- The usePoolDayDatas allow the token addresses as argument. When we pass the different list of token address, it triggers request to retrieve data. We should retrieve pool day data in single request and query daily swaps by pool address.

## Attached Links

1. Jira ticket: [IXSPD1-2749]
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
