### PR TITLE
Release patch v1.7.3 - Update Blackrock HYCB Vault APY on IXS

### DIFF
--- a/src/pages/Earn/ProductDetail/components/AnnualPercentageRate.tsx
+++ b/src/pages/Earn/ProductDetail/components/AnnualPercentageRate.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components/macro'
+import { getPublicClient, readContract } from '@wagmi/core'
+
+import LoadingBlock from '../../components/LoadingBlock'
+import OpenTradeABI from '../../abis/OpenTrade.json'
+import { wagmiConfig } from 'components/Web3Provider'
+
+interface AnnualPercentageRateProps {
+  chainId: number
+  opentradeVaultAddress: string | undefined
+}
+
+async function getPoolDynamicOverviewStateForClient(client: any, contract: any, chainId: number) {
+  if (!contract.address) return null
+  return await readContract(wagmiConfig, {
+    ...contract,
+    functionName: 'getPoolDynamicOverviewState',
+    chainId,
+    client,
+  })
+}
+
+export const AnnualPercentageRate: React.FC<AnnualPercentageRateProps> = ({ opentradeVaultAddress, chainId }) => {
+  const [indicativeInterestRatePercentage, setIndicativeInterestRatePercentage] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  const openTradeContract = {
+    address: opentradeVaultAddress as `0x${string}` | undefined,
+    abi: OpenTradeABI,
+  } as const
+
+  useEffect(() => {
+    async function fetchData() {
+      if (!openTradeContract.address) return
+      try {
+        setLoading(true)
+        const client = getPublicClient(wagmiConfig, {
+          chainId,
+        })
+        const poolDynamicOverviewStateResult: any = await getPoolDynamicOverviewStateForClient(
+          client,
+          openTradeContract,
+          chainId
+        )
+        const indicativeInterestRate = (poolDynamicOverviewStateResult?.indicativeInterestRate || 0).toString()
+        const finalRate = (parseFloat(indicativeInterestRate) / 100).toFixed(2)
+
+        setIndicativeInterestRatePercentage(finalRate)
+        setLoading(false)
+      } catch (error) {
+        console.error('Error fetching pool dynamic overview state:', error)
+        setIndicativeInterestRatePercentage('N/A')
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [openTradeContract.address])
+
+  return (
+    <InfoCard>
+      <InfoCardLabel>Annual Percentage Rate</InfoCardLabel>
+
+      {loading ? (
+        <LoadingBlock className="rate-number" />
+      ) : (
+        <ApyBigText>{indicativeInterestRatePercentage}%</ApyBigText>
+      )}
+    </InfoCard>
+  )
+}
+
+const InfoCard = styled.div`
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0px 30px 48px 0px rgba(63, 63, 132, 0.05);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1 0 0;
+  align-self: stretch;
+  padding: 24px;
+
+  @media (min-width: 768px) {
+    padding: 40px;
+  }
+
+  .rate-number {
+    width: 187px;
+    height: 60px;
+  }
+`
+
+const InfoCardLabel = styled.div`
+  color: #8f8fb2;
+  font-family: Inter;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  letter-spacing: -0.28px;
+
+  @media (min-width: 768px) {
+    font-size: 16px;
+  }
+`
+
+const ApyBigText = styled.div`
+  color: #66f;
+  text-align: right;
+  font-family: Inter;
+  font-size: 40px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 60px; /* 150% */
+  letter-spacing: -1.6px;
+
+  @media (min-width: 768px) {
+    color: #66f;
+    font-size: 64px;
+    line-height: 60px; /* 93.75% */
+    letter-spacing: -2.56px;
+  }
+`

--- a/src/pages/Earn/ProductDetail/components/AnnualPercentageRate.tsx
+++ b/src/pages/Earn/ProductDetail/components/AnnualPercentageRate.tsx
@@ -59,7 +59,7 @@ export const AnnualPercentageRate: React.FC<AnnualPercentageRateProps> = ({ open
 
   return (
     <InfoCard>
-      <InfoCardLabel>Annual Percentage Rate</InfoCardLabel>
+      <InfoCardLabel>Current APY</InfoCardLabel>
 
       {loading ? (
         <LoadingBlock className="rate-number" />

--- a/src/pages/Earn/ProductDetail/index.tsx
+++ b/src/pages/Earn/ProductDetail/index.tsx
@@ -9,23 +9,23 @@ import Portal from '@reach/portal'
 import { Copy, ExternalLink, Link } from 'react-feather'
 
 import { useActiveWeb3React } from 'hooks/web3'
-import { EarnProduct, products } from './products'
+import { EarnProduct, products } from '../products'
 import { useSubgraphQuery } from 'hooks/useSubgraphQuery'
 import { formatAmount } from 'utils/formatCurrencyAmount'
-import { DepositTab } from './components/tabs/Deposit'
-import { WithdrawRequestTab } from './components/tabs/WithdrawRequest'
-import { ClaimTab } from './components/tabs/Claim'
+import { DepositTab } from '../components/tabs/Deposit'
+import { WithdrawRequestTab } from '../components/tabs/WithdrawRequest'
+import { ClaimTab } from '../components/tabs/Claim'
+import { AnnualPercentageRate } from './components/AnnualPercentageRate'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { checkWrongChain } from 'utils/chains'
 import { CenteredFixed } from 'components/LaunchpadMisc/styled'
 import { NetworkNotAvailable } from 'components/Launchpad/NetworkNotAvailable'
 
-import OpenTradeABI from './abis/OpenTrade.json'
-import USDCIcon from '../../assets/images/usdcNew.svg'
+import OpenTradeABI from '../abis/OpenTrade.json'
+import USDCIcon from 'assets/images/usdcNew.svg'
 import { Box, Flex } from 'rebass'
 import { isMobile } from 'react-device-detect'
-import { useMulticall } from './hooks/useMulticall'
-import LoadingBlock from './components/LoadingBlock'
+import { useMulticall } from '../hooks/useMulticall'
 interface Transaction {
   date: number
   type: string
@@ -307,15 +307,7 @@ export default function ProductDetail() {
             ) : null}
           </InfoCard>
 
-          <InfoCard>
-            <InfoCardLabel>Annual Percentage Rate</InfoCardLabel>
-
-            {isLoadingGetRate ? (
-              <LoadingBlock className="rate-number" />
-            ) : (
-              <ApyBigText>{indicativeInterestRatePercentage}%</ApyBigText>
-            )}
-          </InfoCard>
+          <AnnualPercentageRate opentradeVaultAddress={product.opentradeVaultAddress} chainId={product.chainId} />
         </InfoCardsSection>
 
         <FormContainer>
@@ -658,24 +650,6 @@ const InfoCardValue = styled.div`
 
   @media (min-width: 768px) {
     font-size: 32px;
-  }
-`
-
-const ApyBigText = styled.div`
-  color: #66f;
-  text-align: right;
-  font-family: Inter;
-  font-size: 40px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 60px; /* 150% */
-  letter-spacing: -1.6px;
-
-  @media (min-width: 768px) {
-    color: #66f;
-    font-size: 64px;
-    line-height: 60px; /* 93.75% */
-    letter-spacing: -2.56px;
   }
 `
 

--- a/src/pages/Earn/components/EarnProductCard.tsx
+++ b/src/pages/Earn/components/EarnProductCard.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from 'react'
-import { getPublicClient, readContract } from '@wagmi/core'
+import React from 'react'
 import styled from 'styled-components/macro'
 import { EarnProduct } from '../products'
 import { Box, Flex } from 'rebass'
-import { wagmiConfig } from 'components/Web3Provider'
-import OpenTradeABI from '../abis/OpenTrade.json'
 import LoadingBlock from './LoadingBlock'
 
 interface EarnProductCardProps {
@@ -12,74 +9,39 @@ interface EarnProductCardProps {
   onClick: () => void
 }
 
-async function getPoolDynamicOverviewStateForClient(client: any, contract: any, chainId: number) {
-  if (!contract.address) return null
-  return await readContract(wagmiConfig, {
-    ...contract,
-    functionName: 'getPoolDynamicOverviewState',
-    chainId,
-    client,
-  })
-}
-
 export function EarnProductCard({ product, onClick }: EarnProductCardProps) {
-  const [indicativeInterestRatePercentage, setIndicativeInterestRatePercentage] = useState('')
-  const [loading, setLoading] = useState(true)
-
-  const openTradeContract = {
-    address: product?.opentradeVaultAddress as `0x${string}` | undefined,
-    abi: OpenTradeABI,
-  } as const
-
-  useEffect(() => {
-    async function fetchData() {
-      if (!openTradeContract.address) return
-      try {
-        setLoading(true)
-        const client = getPublicClient(wagmiConfig, {
-          chainId: product.chainId,
-        })
-        const poolDynamicOverviewStateResult: any = await getPoolDynamicOverviewStateForClient(
-          client,
-          openTradeContract,
-          product.chainId
-        )
-        const indicativeInterestRate = (poolDynamicOverviewStateResult?.indicativeInterestRate || 0).toString()
-        const finalRate = (parseFloat(indicativeInterestRate) / 100).toFixed(2)
-
-        setIndicativeInterestRatePercentage(finalRate)
-        setLoading(false)
-      } catch (error) {
-        console.error('Error fetching pool dynamic overview state:', error)
-        setIndicativeInterestRatePercentage('N/A')
-        setLoading(false)
-      }
-    }
-    fetchData()
-  }, [openTradeContract.address])
-
   return (
     <CardContainer cornerImageUrl={product.bgUrl}>
       <Flex flexDirection="column" height="100%" justifyContent="space-between">
         <Flex justifyContent="space-between">
           <div>
-            {loading ? (
-              <LoadingBlock className="rate-number" />
-            ) : (
-              <Box
-                sx={{
-                  color: '#66F',
-                  fontFamily: 'Inter',
-                  fontSize: ['28px', '36px', '48px'],
-                  fontStyle: 'normal',
-                  fontWeight: 700,
-                  lineHeight: 'normal',
-                  letterSpacing: ['-1.1px', '-1.5px', '-1.92px'],
-                }}
-              >
-                {indicativeInterestRatePercentage}%
-              </Box>
-            )}
+            <Box
+              sx={{
+                color: '#66F',
+                fontFamily: 'Inter',
+                fontSize: '14px',
+                fontStyle: 'normal',
+                fontWeight: 500,
+                lineHeight: 'normal',
+                letterSpacing: '-0.28px',
+              }}
+            >
+              Up to
+            </Box>
+
+            <Box
+              sx={{
+                color: '#66F',
+                fontFamily: 'Inter',
+                fontSize: ['28px', '36px', '48px'],
+                fontStyle: 'normal',
+                fontWeight: 700,
+                lineHeight: 'normal',
+                letterSpacing: ['-1.1px', '-1.5px', '-1.92px'],
+              }}
+            >
+              {product.apyUpto * 100}%
+            </Box>
 
             <Box
               sx={{
@@ -92,7 +54,7 @@ export function EarnProductCard({ product, onClick }: EarnProductCardProps) {
                 letterSpacing: ['-0.15px', '-0.22px', '-0.28px'],
               }}
             >
-              Annual Percentage Rate
+              Annual Percentage Yield (APY)
             </Box>
           </div>
           <div>

--- a/src/pages/Earn/products.ts
+++ b/src/pages/Earn/products.ts
@@ -22,6 +22,7 @@ export interface EarnProduct {
   bgUrl: string // background image URL for the product
   bgFullUrl: string // full background image URL for the product
   learnMoreUrl?: string // optional URL for more information about the product
+  apyUpto: number // optional maximum APY for the product
 }
 
 // Base product data without environment-specific values
@@ -64,6 +65,7 @@ const baseProducts: Omit<EarnProduct, 'address' | 'investingTokenAddress' | 'ope
     bgUrl: '/images/earn/bg-hycb.svg',
     bgFullUrl: '/images/earn/image02.svg',
     learnMoreUrl: 'https://docs.opentrade.io/stablecoin-yield/stablecoin-yield-vaults/high-yield-corporate-bond-vault',
+    apyUpto: 0.085,
   },
 ]
 


### PR DESCRIPTION
# 📝 Release Note – v1.7.3

**Release Date:** July 11, 2025

---

## ✨ Summary

This patch focuses on updating the **Blackrock HYCB Vault APY** displayed on the IXS platform to ensure accurate yield information for users.

---

## 🛠 Changes

- **Earn Module Fix:**  
  Resolved an issue where APR displayed as **0%** when users cleared local storage, ensuring APY and APR values are fetched and shown correctly regardless of local cache state.

- **Blackrock HYCB Vault Update:**  
  Updated the **HYCB Vault APY** on IXS to reflect the latest yield data from Blackrock, improving user confidence and aligning with real-time yield offerings.

---

## 🐞 Bug Fixes

- **APR Display Issue:**  
  Fixed an edge case where clearing local storage caused Earn module APR to reset to 0% until a full refresh.

---

## 🔗 Impact

- **User-facing:** Correct APY visibility in Earn for HYCB vault.  
- **Backend:** No migrations or schema changes required.  
- **Front-end:** Minor hot patch for Earn display logic.

---

## 👤 Author

- Thuong To (@leonthuongto)

---
